### PR TITLE
Default osSuffix to runtime.GOOS instead of calling panic()

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -94,12 +94,10 @@ var osSuffix string
 
 func init() {
 	switch value := runtime.GOOS; value {
-	case "linux", "freebsd", "windows":
-		osSuffix = runtime.GOOS
 	case "darwin":
 		osSuffix = "macosx"
 	default:
-		panic("Unsupported OS")
+		osSuffix = runtime.GOOS
 	}
 }
 

--- a/properties_test.go
+++ b/properties_test.go
@@ -58,20 +58,14 @@ func TestPropertiesTestTxt(t *testing.T) {
 	p, err := Load(filepath.Join("testdata", "test.txt"))
 
 	require.NoError(t, err)
-
-	require.Equal(t, 4, p.Size())
 	require.Equal(t, "value = 1", p.Get("key"))
 
-	switch value := runtime.GOOS; value {
-	case "linux":
-		require.Equal(t, "is linux", p.Get("which.os"))
-	case "windows":
-		require.Equal(t, "is windows", p.Get("which.os"))
-	case "darwin":
-		require.Equal(t, "is macosx", p.Get("which.os"))
-	default:
-		require.FailNow(t, "unsupported OS")
+	runOS := runtime.GOOS
+	if runOS == "darwin" {
+		runOS = "macosx"
 	}
+
+	require.Equal(t, fmt.Sprintf("is %s", runOS), p.Get("which.os"))
 }
 
 func TestExpandPropsInStringAndMissingCheck(t *testing.T) {

--- a/testdata/test.txt
+++ b/testdata/test.txt
@@ -6,3 +6,6 @@ which.os=dunno
 which.os.linux=is linux
 which.os.macosx=is macosx
 which.os.windows=is windows
+which.os.openbsd=is openbsd
+which.os.freebsd=is freebsd
+which.os.netbsd=is netbsd


### PR DESCRIPTION
- update properties_test to not require a full list of OSs.
- add free, open and net BSD to the test data.