### PR TITLE
Allow ISO8859-1 encoding in properties

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -77,6 +77,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/arduino/go-paths-helper"
 )
@@ -129,9 +130,23 @@ func NewFromHashmap(orig map[string]string) *Map {
 	return res
 }
 
+func toUtf8(iso8859_1_buf []byte) string {
+	buf := make([]rune, len(iso8859_1_buf))
+	for i, b := range iso8859_1_buf {
+		buf[i] = rune(b)
+	}
+	return string(buf)
+}
+
 // LoadFromBytes reads properties data and makes a Map out of it.
 func LoadFromBytes(bytes []byte) (*Map, error) {
-	text := string(bytes)
+	var text string
+	if utf8.Valid(bytes) {
+		text = string(bytes)
+	} else {
+		// Assume ISO8859-1 encoding and convert to UTF-8
+		text = toUtf8(bytes)
+	}
 	text = strings.Replace(text, "\r\n", "\n", -1)
 	text = strings.Replace(text, "\r", "\n", -1)
 

--- a/properties_test.go
+++ b/properties_test.go
@@ -384,3 +384,9 @@ func TestExtractSubIndexLists(t *testing.T) {
 	s5 := m.ExtractSubIndexLists("cinque.discovery.required")
 	require.Len(t, s5, 0)
 }
+
+func TestLoadingNonUTF8Properties(t *testing.T) {
+	m, err := LoadFromPath(paths.New("testdata/non-utf8.properties"))
+	require.NoError(t, err)
+	require.Equal(t, "Aáa", m.Get("maintainer"))
+}

--- a/testdata/non-utf8.properties
+++ b/testdata/non-utf8.properties
@@ -1,0 +1,1 @@
+maintainer=Aáa


### PR DESCRIPTION
A `.properties` file is parsed as UTF-8 encoded, but if we found some non UTF-8 characters, we now assume it's ISO8859-1 and we convert it back to UTF-8. It is common to find ISO8859-1 encoded `.properties` files in old java projects.

ISO8859-1 range is 0x00-0xFF so the conversion is done by simply converting each byte in the corresponding code point in UTF-8: https://stackoverflow.com/a/13511463/1655275

> `rune` is an alias for `int32`, and when it comes to encoding, a rune is assumed to have a Unicode character value (code point). So the value `b` in `rune(b)` should be a unicode value. For 0x00 - 0xFF this value is identical to Latin-1, so you don't have to worry about it.
>
> Then you need to encode the runes into UTF8. But this encoding is simply done by converting a `[]rune` to `string`.

