### PR TITLE
feat: map as slice

### DIFF
--- a/properties.go
+++ b/properties.go
@@ -485,10 +485,20 @@ func (m *Map) Values() []string {
 	return values
 }
 
-// AsMap return the underlying map[string]string. This is useful if you need to
+// AsMap returns the underlying map[string]string. This is useful if you need to
 // for ... range but without the requirement of the ordered elements.
 func (m *Map) AsMap() map[string]string {
 	return m.kv
+}
+
+// AsSlice returns the underlying map[string]string as a slice of
+// strings with the pattern `{key}={value}`, maintaining the insertion order of the keys.
+func (m *Map) AsSlice() []string {
+	properties := make([]string, len(m.o))
+	for i, key := range m.o {
+		properties[i] = strings.Join([]string{key, m.kv[key]}, "=")
+	}
+	return properties
 }
 
 // Clone makes a copy of the Map

--- a/properties_test.go
+++ b/properties_test.go
@@ -390,3 +390,21 @@ func TestLoadingNonUTF8Properties(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "Aáa", m.Get("maintainer"))
 }
+
+func TestAsSlice(t *testing.T) {
+	emptyProperties := NewMap()
+	require.Len(t, emptyProperties.AsSlice(), 0)
+
+	properties := NewMap()
+	properties.Set("key1", "value1")
+	properties.Set("key2", "value2")
+	properties.Set("key3", "value3=somethingElse")
+
+	require.Len(t, properties.AsSlice(), properties.Size())
+
+	require.Equal(t, []string{
+		"key1=value1",
+		"key2=value2",
+		"key3=value3=somethingElse"},
+		properties.AsSlice())
+}


### PR DESCRIPTION
Represents a properties map as a slice of string with pattern`{key}={value}`.
Basically the opposite of the `LoadFromSlice([]string) *Map` constructor